### PR TITLE
Fix for case issues with "fach" search

### DIFF
--- a/Resources/Public/JavaScript/SubTabs.js
+++ b/Resources/Public/JavaScript/SubTabs.js
@@ -438,6 +438,7 @@
 
   fachMatchesTerm = function(fach, filterTerm) {
     var fachArray, result, tag, tagID;
+    filterTerm = filterTerm.toLowerCase();
     fachArray = [];
     tagID = void 0;
     tag = void 0;


### PR DESCRIPTION
Currently, the search term has to be lower-case, even if the result contains upper-case characters.
